### PR TITLE
security: fix GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,14 @@
 name: CI/CD Pipeline
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   quality-gates:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       
@@ -35,6 +40,8 @@ jobs:
     needs: quality-gates
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Toutes les évolutions notables du template sont listées ici.
 
+## [Unreleased]
+
+### Security
+- ✅ Fix GitHub Actions workflow permissions (CodeQL alerts #1, #2)
+- ✅ Add explicit permissions blocks to restrict GITHUB_TOKEN scope
+- ✅ Follow principle of least privilege for CI/CD workflows
+
 ## [0.1.0] – 2025-06-23
 
 ### Added


### PR DESCRIPTION
## Summary
- Fix CodeQL security alerts #1 and #2 (medium severity)
- Add explicit permissions blocks to restrict GITHUB_TOKEN scope
- Follow principle of least privilege for CI/CD workflows

## Changes
- Add workflow-level `permissions: contents: read` 
- Add job-level `permissions: contents: read` for quality-gates
- Add job-level `permissions: contents: write` for deploy-staging (tagging requirement)
- Update CHANGELOG.md with security fixes

## Test plan
- [x] Verify CI pipeline still passes
- [x] Confirm CodeQL alerts are resolved
- [x] Check that permissions are restrictive but functional

🤖 Generated with [Claude Code](https://claude.ai/code)